### PR TITLE
add -v/-q cli arguments to control verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 
 * New `cloud_cover` segment to show the current cloud cover in %.
+* New `-v/-q` pair of short options to respectively increase/decrease verbosity. The options can be stacked (`-vvv`). The default verbosity level is `warn` (from `off`, `error`, `warn`, `info`, `debug`, `trace`), with the cli arguments overriding the `GIROUETTE_LOG` environment variable. `-qq` silences all output except weather segments.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,12 +182,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
- "humantime 1.3.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -308,11 +308,11 @@ dependencies = [
  "dbus",
  "dbus-tokio",
  "directories-next",
+ "env_logger",
  "futures-util",
  "hex",
- "humantime 2.1.0",
+ "humantime",
  "log",
- "pretty_env_logger",
  "reqwest",
  "serde",
  "serde_json",
@@ -404,15 +404,6 @@ name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
 
 [[package]]
 name = "humantime"
@@ -750,16 +741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,12 +784,6 @@ checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,72 +1,70 @@
 [package]
-name = 'girouette'
+name = "girouette"
 version = "0.6.0-dev"
-authors = ['Antoine Gourlay <antoine@gourlay.fr>']
-edition = '2018'
+authors = ["Antoine Gourlay <antoine@gourlay.fr>"]
+edition = "2018"
 
 [dependencies]
 anyhow = "1"
-chrono = '0.4'
-directories-next = '2'
-humantime = '2'
-log = '0.4'
-pretty_env_logger = '0.4'
-termcolor = '1.1'
-serde_json = '1'
+chrono = "0.4"
+directories-next = "2"
+humantime = "2"
+log = "0.4"
+env_logger = "0.8"
+termcolor = "1.1"
+serde_json = "1"
 hex = "0.4"
-dbus-tokio = { version = '0.7', optional = true }
-futures-util = { version = '0.3', optional = true }
+dbus-tokio = { version = "0.7", optional = true }
+futures-util = { version = "0.3", optional = true }
 
 [dependencies.reqwest]
-version = '0.11'
+version = "0.11"
 default-features = false
 
 # use rusttls when building a static executable:
 # until rust-lang/cargo/issues/2524 is stable we need features to do this
 [features]
-default = ['dynamic', 'geoclue']
+default = ["dynamic", "geoclue"]
 # cannot support geoclue in a static build: dbus-rs cannot be built statically
 # (dbus-1 links to a whole bunch of things, like systemd)
-default-static = ['static']
+default-static = ["static"]
 
-dynamic = ['reqwest/default-tls']
-static = ['reqwest/rustls-tls']
-geoclue = ['dbus', 'dbus-tokio', 'futures-util']
+dynamic = ["reqwest/default-tls"]
+static = ["reqwest/rustls-tls"]
+geoclue = ["dbus", "dbus-tokio", "futures-util"]
 
 [dependencies.structopt]
-version = '0.3'
+version = "0.3"
 default-features = false
-features = ['suggestions']
+features = ["suggestions"]
 
 [build-dependencies.structopt]
-version = '0.3'
+version = "0.3"
 default-features = false
-features = ['suggestions']
+features = ["suggestions"]
 
 [dependencies.config]
-version = '0.11'
+version = "0.11"
 default-features = false
-features = ['yaml']
+features = ["yaml"]
 
 [dependencies.serde]
-version = '1'
-features = ['derive']
-
-[build-dependencies.serde]
-version = '1'
-features = ['derive']
+version = "1"
+features = ["derive"]
 
 [dependencies.tokio]
-version = '1'
-features = ['rt']
+version = "1"
+features = ["rt"]
 
 [dependencies.dbus]
-version = '0.9'
-features = ['futures']
+version = "0.9"
+features = ["futures"]
 optional = true
 
 [build-dependencies]
 version_check = "0.9"
+serde = { version = "1", features = ["derive"] }
+log = "0.4"
 
 [profile.release]
 lto = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -81,4 +82,38 @@ pub struct ProgramOptions {
     /// Prints version information.
     #[structopt(short = "V", long = "version")]
     pub version: bool,
+
+    /// Pass for more log output.
+    #[structopt(long, short, global = true, parse(from_occurrences))]
+    verbose: i8,
+
+    /// Pass for less log output.
+    #[structopt(
+        long,
+        short,
+        global = true,
+        parse(from_occurrences),
+        conflicts_with = "verbose"
+    )]
+    quiet: i8,
+}
+
+impl ProgramOptions {
+    pub fn log_level_with_default(&self, default: i8) -> Option<LevelFilter> {
+        let level = default + self.verbose - self.quiet;
+        let new_level = match level {
+            i8::MIN..=0 => LevelFilter::Off,
+            1 => LevelFilter::Error,
+            2 => LevelFilter::Warn,
+            3 => LevelFilter::Info,
+            4 => LevelFilter::Debug,
+            5..=i8::MAX => LevelFilter::Trace,
+        };
+
+        if level != default {
+            Some(new_level)
+        } else {
+            None
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,3 +262,17 @@ pub enum DisplayMode {
     Unicode,
     Ascii,
 }
+
+#[macro_export]
+macro_rules! show {
+    ($level:ident, $($a:tt),*) => {
+        if log_enabled!(log::Level::$level) {
+            println!($($a,)*);
+        }
+    };
+    ($($a:tt),*) => {
+        if log_enabled!(log::Level::Error) {
+            println!($($a,)*);
+        }
+    }
+}


### PR DESCRIPTION
Also drop pretty_env_logger for standard env_logger, and print to stdout
on error instead of logging.
