### PR TITLE
Initial forecast support

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,6 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+          id: get-latest-tag
+          if: ${{ github.event_name == 'schedule' }}
+      - name: Switch to latest tag
+          run: git checkout ${{ steps.get-latest-tag.outputs.tag }}
+          if: ${{ github.event_name == 'schedule' }}
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.48.0 # Rust MSRV
+          - 1.53.0 # Rust MSRV
     steps:
       - uses: actions/checkout@v2
       - name: Install native dependencies
@@ -42,7 +42,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.48.0 # Rust MSRV
+          - 1.53.0 # Rust MSRV
     steps:
       - uses: actions/checkout@v2
       - name: Install native dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "arrayvec"
@@ -48,9 +48,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "dbus-tokio"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4083ad3ad374032aaacf18c4cce2c65c3ba5d4e576a037339a8b6cd0b4509c"
+checksum = "7fdf8ad870c4824f71f40fd16776b6ee841c89703d6c9d1608c547a2c8c3ffda"
 dependencies = [
  "dbus",
  "libc",
@@ -229,24 +229,24 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -257,21 +257,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
  "autocfg",
  "futures-core",
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
 dependencies = [
  "bytes",
  "fnv",
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes",
  "http",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
@@ -410,9 +410,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -489,15 +489,15 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
 
 [[package]]
 name = "libdbus-sys"
@@ -553,15 +553,15 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "mime"
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -656,9 +656,9 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "openssl"
-version = "0.10.35"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -676,9 +676,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.65"
+version = "0.9.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
+checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
 dependencies = [
  "autocfg",
  "cc",
@@ -755,9 +755,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -973,18 +973,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "1056a0db1978e9dbf0f6e4fca677f6f9143dc1c19de346f22cac23e422196834"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "13af2fbb8b60a8950d6c72a56d2095c28870367cc8e10c55e9745bac4995a2c4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -993,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -1016,15 +1016,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi",
@@ -1074,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1142,9 +1142,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1209,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -1224,12 +1224,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -1306,9 +1303,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
  "cfg-if",
  "serde",
@@ -1318,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1333,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1345,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1355,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1368,15 +1365,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The location can be set and the output customized in the [configuration file](#c
 ## Building from source
 
 girouette is written in Rust, so you need a [Rust install] to build it. girouette compiles with
-Rust 1.48 or newer.
+Rust 1.48 or newer (1.53 to build `main`).
 
 Building a dynamically-linked girouette (the default) also requires d-bus (for geolocalization support) and OpenSSL 
 (`libdbus-1-dev` and `libssl-dev` on Ubuntu, `dbus-devel` and `openssl-devel` on Fedora).

--- a/example_configs/forecast.yml
+++ b/example_configs/forecast.yml
@@ -31,4 +31,5 @@ segments:
       style:
         fg: "#c4be89"
   - temperature
+  - hourly_forecast
   - daily_forecast

--- a/example_configs/forecast.yml
+++ b/example_configs/forecast.yml
@@ -1,0 +1,34 @@
+# Example config file for girouette
+
+# This is a default key for girouette. It is rate-limited, so
+# get a free API key over at https://openweathermap.org/
+key: "467cf0f1a1d612944d2da01c515c6f26"
+
+location: "London"
+
+cache: "10m"
+
+base_style:
+  bg: "#1b1d1e"
+  fg: "#f8f8f2"
+
+display_mode: "unicode"
+
+# Segments to display
+segments:
+  - instant:
+      style:
+        fg: "#fd971f"
+      date_format: "%R"
+  - location_name:
+      style:
+        fg: "#ae81ff"
+        intense: true
+  - weather_icon:
+      style:
+        fg: "#c4be89"
+  - weather_description:
+      style:
+        fg: "#c4be89"
+  - temperature
+  - daily_forecast

--- a/src/api/current.rs
+++ b/src/api/current.rs
@@ -1,14 +1,16 @@
+use super::*;
+
 #[derive(serde::Deserialize)]
 #[serde(untagged)]
 pub enum ApiResponse {
-    Success(WeatherResponse),
+    Success(CurrentResponse),
     // hack: Openweather API returns some very ugly json
     OtherInt { cod: u16, message: String },
     OtherString { cod: String, message: String },
 }
 
 #[derive(serde::Deserialize, Debug)]
-pub struct WeatherResponse {
+pub struct CurrentResponse {
     pub coord: Coord,
     pub weather: Vec<Weather>,
     pub main: Main,
@@ -31,14 +33,6 @@ pub struct Coord {
 }
 
 #[derive(serde::Deserialize, Debug)]
-pub struct Weather {
-    pub id: u16,
-    pub main: String,
-    pub description: String,
-    pub icon: String,
-}
-
-#[derive(serde::Deserialize, Debug)]
 pub struct Main {
     pub temp: f32,
     pub feels_like: f32,
@@ -53,22 +47,6 @@ pub struct Wind {
     pub speed: f32,
     pub deg: Option<f32>,
     pub gale: Option<f32>,
-}
-
-#[derive(serde::Deserialize, Debug)]
-pub struct Rain {
-    #[serde(rename(deserialize = "1h"))]
-    pub one_h: Option<f32>,
-    #[serde(rename(deserialize = "3h"))]
-    pub three_h: Option<f32>,
-}
-
-#[derive(serde::Deserialize, Debug)]
-pub struct Snow {
-    #[serde(rename(deserialize = "1h"))]
-    pub one_h: Option<f32>,
-    #[serde(rename(deserialize = "3h"))]
-    pub three_h: Option<f32>,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/src/api/current.rs
+++ b/src/api/current.rs
@@ -28,8 +28,8 @@ pub struct CurrentResponse {
 
 #[derive(serde::Deserialize, Debug)]
 pub struct Coord {
-    pub lat: f32,
-    pub lon: f32,
+    pub lat: f64,
+    pub lon: f64,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,7 @@
+use anyhow::*;
+
 pub mod current;
+pub mod one_call;
 
 #[derive(serde::Deserialize, Debug)]
 pub struct Weather {
@@ -22,4 +25,54 @@ pub struct Snow {
     pub one_h: Option<f32>,
     #[serde(rename(deserialize = "3h"))]
     pub three_h: Option<f32>,
+}
+
+#[derive(Debug)]
+pub struct Response {
+    current: Option<current::CurrentResponse>,
+    forecast: Option<one_call::OneCallResponse>,
+}
+
+impl Response {
+    pub fn from_current(current: current::CurrentResponse) -> Self {
+        Self {
+            current: Some(current),
+            forecast: None,
+        }
+    }
+
+    pub fn from_forecast(forecast: one_call::OneCallResponse) -> Self {
+        Self {
+            current: None,
+            forecast: Some(forecast),
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            current: None,
+            forecast: None,
+        }
+    }
+
+    pub fn merge(&mut self, other: Response) {
+        if let Some(c) = other.current {
+            self.current.insert(c);
+        }
+        if let Some(f) = other.forecast {
+            self.forecast.insert(f);
+        }
+    }
+
+    pub fn as_current(&self) -> Result<&current::CurrentResponse> {
+        self.current
+            .as_ref()
+            .ok_or_else(|| anyhow!("internal error: missing current api data"))
+    }
+
+    pub fn as_forecast(&self) -> Result<&one_call::OneCallResponse> {
+        self.forecast
+            .as_ref()
+            .ok_or_else(|| anyhow!("internal error: missing forecast api data"))
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,25 @@
+pub mod current;
+
+#[derive(serde::Deserialize, Debug)]
+pub struct Weather {
+    pub id: u16,
+    pub main: String,
+    pub description: String,
+    pub icon: String,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct Rain {
+    #[serde(rename(deserialize = "1h"))]
+    pub one_h: Option<f32>,
+    #[serde(rename(deserialize = "3h"))]
+    pub three_h: Option<f32>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct Snow {
+    #[serde(rename(deserialize = "1h"))]
+    pub one_h: Option<f32>,
+    #[serde(rename(deserialize = "3h"))]
+    pub three_h: Option<f32>,
+}

--- a/src/api/one_call.rs
+++ b/src/api/one_call.rs
@@ -1,0 +1,100 @@
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+pub enum ApiResponse {
+    Success(OneCallResponse),
+    // hack: Openweather API returns some very ugly json
+    OtherInt { cod: u16, message: String },
+    OtherString { cod: String, message: String },
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct OneCallResponse {
+    pub lat: f32,
+    pub lon: f32,
+    pub current: WeatherData,
+    pub minutely: Vec<MinutelyForecast>,
+    pub hourly: Vec<WeatherData>,
+    pub daily: Vec<WeatherData>,
+    pub alerts: Option<Vec<Alert>>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct WeatherData {
+    pub dt: i64,
+    pub sunrise: Option<i64>,
+    pub sunset: Option<i64>,
+    pub temp: Temperature,
+    pub feels_like: FeelsLike,
+    pub pressure: u16,
+    pub humidity: u8,
+    pub clouds: u16,
+    pub visibility: Option<u16>,
+    pub wind_speed: f32,
+    pub wind_deg: Option<f32>,
+    pub wind_gust: Option<f32>,
+    pub pop: Option<f32>,
+    pub rain: Option<RainResult>,
+    pub snow: Option<SnowResult>,
+    pub weather: Vec<super::Weather>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(untagged)]
+pub enum RainResult {
+    Value(f32),
+    Values(super::Rain),
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(untagged)]
+pub enum SnowResult {
+    Value(f32),
+    Values(super::Snow),
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(untagged)]
+pub enum Temperature {
+    Value(f32),
+    Values(TempValues),
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct TempValues {
+    pub morn: f32,
+    pub day: f32,
+    pub eve: f32,
+    pub night: f32,
+    pub min: f32,
+    pub max: f32,
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(untagged)]
+pub enum FeelsLike {
+    Value(f32),
+    Values(FeelsLikeValues),
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct FeelsLikeValues {
+    pub morn: f32,
+    pub day: f32,
+    pub eve: f32,
+    pub night: f32,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct MinutelyForecast {
+    pub dt: i64,
+    pub precipitation: f32,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub struct Alert {
+    pub sender_name: String,
+    pub event: String,
+    pub start: i64,
+    pub end: i64,
+    pub description: String,
+}

--- a/src/api/one_call.rs
+++ b/src/api/one_call.rs
@@ -11,6 +11,7 @@ pub enum ApiResponse {
 pub struct OneCallResponse {
     pub lat: f32,
     pub lon: f32,
+    pub timezone_offset: i32,
     pub current: WeatherData,
     pub minutely: Vec<MinutelyForecast>,
     pub hourly: Vec<WeatherData>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ impl Default for ProgramConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct DisplayConfig {
     #[serde(with = "FakeColorSpec")]

--- a/src/geoclue/client.rs
+++ b/src/geoclue/client.rs
@@ -146,7 +146,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn location(&self) -> nonblock::MethodReply<dbus::Path<'static>> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Client",
             "Location",
         )
@@ -154,7 +154,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn distance_threshold(&self) -> nonblock::MethodReply<u32> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Client",
             "DistanceThreshold",
         )
@@ -162,7 +162,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn time_threshold(&self) -> nonblock::MethodReply<u32> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Client",
             "TimeThreshold",
         )
@@ -170,7 +170,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn desktop_id(&self) -> nonblock::MethodReply<String> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Client",
             "DesktopId",
         )
@@ -178,7 +178,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn requested_accuracy_level(&self) -> nonblock::MethodReply<u32> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Client",
             "RequestedAccuracyLevel",
         )
@@ -186,7 +186,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn active(&self) -> nonblock::MethodReply<bool> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Client",
             "Active",
         )
@@ -194,7 +194,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn set_distance_threshold(&self, value: u32) -> nonblock::MethodReply<()> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::set(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Client",
             "DistanceThreshold",
             value,
@@ -203,7 +203,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn set_time_threshold(&self, value: u32) -> nonblock::MethodReply<()> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::set(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Client",
             "TimeThreshold",
             value,
@@ -212,7 +212,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn set_desktop_id(&self, value: String) -> nonblock::MethodReply<()> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::set(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Client",
             "DesktopId",
             value,
@@ -221,7 +221,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn set_requested_accuracy_level(&self, value: u32) -> nonblock::MethodReply<()> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::set(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Client",
             "RequestedAccuracyLevel",
             value,

--- a/src/geoclue/location.rs
+++ b/src/geoclue/location.rs
@@ -134,7 +134,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>>
 {
     fn latitude(&self) -> nonblock::MethodReply<f64> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Location",
             "Latitude",
         )
@@ -142,7 +142,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>>
 
     fn longitude(&self) -> nonblock::MethodReply<f64> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Location",
             "Longitude",
         )
@@ -150,7 +150,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>>
 
     fn accuracy(&self) -> nonblock::MethodReply<f64> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Location",
             "Accuracy",
         )
@@ -158,7 +158,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>>
 
     fn altitude(&self) -> nonblock::MethodReply<f64> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Location",
             "Altitude",
         )
@@ -166,7 +166,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>>
 
     fn speed(&self) -> nonblock::MethodReply<f64> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Location",
             "Speed",
         )
@@ -174,7 +174,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>>
 
     fn heading(&self) -> nonblock::MethodReply<f64> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Location",
             "Heading",
         )
@@ -182,7 +182,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>>
 
     fn description(&self) -> nonblock::MethodReply<String> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Location",
             "Description",
         )
@@ -190,7 +190,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>>
 
     fn timestamp(&self) -> nonblock::MethodReply<(u64, u64)> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Location",
             "Timestamp",
         )

--- a/src/geoclue/manager.rs
+++ b/src/geoclue/manager.rs
@@ -154,7 +154,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn in_use(&self) -> nonblock::MethodReply<bool> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Manager",
             "InUse",
         )
@@ -162,7 +162,7 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgFreede
 
     fn available_accuracy_level(&self) -> nonblock::MethodReply<u32> {
         <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
+            self,
             "org.freedesktop.GeoClue2.Manager",
             "AvailableAccuracyLevel",
         )

--- a/src/geoclue/mod.rs
+++ b/src/geoclue/mod.rs
@@ -43,11 +43,15 @@ pub async fn get_location(timeout_duration: Duration) -> Result<Location> {
         .add_match(OrgFreedesktopGeoClue2ClientLocationUpdated::match_rule(
             None, None,
         ))
-        .await.context("D-bus error")?
+        .await
+        .context("D-bus error")?
         .stream();
 
     // required to be able to query geoclue
-    client.set_desktop_id("girouette".to_string()).await.context("D-bus error")?;
+    client
+        .set_desktop_id("girouette".to_string())
+        .await
+        .context("D-bus error")?;
 
     client.start().await.context("D-bus error")?;
 
@@ -57,7 +61,9 @@ pub async fn get_location(timeout_duration: Duration) -> Result<Location> {
             .map_err(|_| anyhow!("geoclue timed-out trying to find your location"))?
             .ok_or_else(|| anyhow!("no location"))?;
 
-    conn.remove_match(incoming.token()).await.context("D-bus error")?;
+    conn.remove_match(incoming.token())
+        .await
+        .context("D-bus error")?;
 
     let location_path = res.1.new;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ impl WeatherClient {
         if let Some(p) = WeatherClient::directories() {
             let suffix = match location {
                 Location::LatLon(lat, lon) => format!("{}_{}", lat, lon),
-                Location::Place(p) => self.clean_up_for_path(&p),
+                Location::Place(p) => self.clean_up_for_path(p),
             };
             let f = if let Some(lang) = language {
                 format!("results/api-{}-{}.json", lang, suffix)
@@ -150,7 +150,7 @@ impl WeatherClient {
         language: Option<&str>,
     ) -> Result<Option<WeatherResponse>> {
         if let Some(cache_length) = self.cache_length {
-            let path = self.find_cache_for(&location, language)?;
+            let path = self.find_cache_for(location, language)?;
 
             if path.exists() {
                 let m = std::fs::metadata(&path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,15 +8,19 @@ mod serde_utils;
 
 use std::time::Duration;
 
+use crate::config::DisplayConfig;
 use anyhow::*;
+use api::{current::ApiResponse as CResponse, one_call::ApiResponse as OResponse, Response};
 use directories_next::ProjectDirs;
 use log::*;
 use reqwest::StatusCode;
-use api::current::{ApiResponse, CurrentResponse};
+use segments::Renderer;
 use serde::{Deserialize, Serialize};
+use termcolor::StandardStream;
 use tokio::time::timeout;
 
-const API_URL: &str = "https://api.openweathermap.org/data/2.5/weather?units=metric";
+const CURRENT_API_URL: &str = "https://api.openweathermap.org/data/2.5/weather?units=metric";
+const ONECALL_API_URL: &str = "https://api.openweathermap.org/data/2.5/onecall?units=metric";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(from = "String", into = "String")]
@@ -70,7 +74,73 @@ impl Location {
     }
 }
 
-#[derive(Default)]
+pub struct Girouette {
+    config: DisplayConfig,
+    cache_length: Option<Duration>,
+    timeout: Duration,
+    key: String,
+    language: Option<String>,
+}
+
+impl Girouette {
+    pub fn new(
+        config: DisplayConfig,
+        cache_length: Option<Duration>,
+        timeout: Duration,
+        key: String,
+        language: Option<String>,
+    ) -> Self {
+        Self {
+            config,
+            cache_length,
+            timeout,
+            key,
+            language,
+        }
+    }
+
+    pub async fn display(&self, loc: &Location, out: &mut StandardStream) -> Result<()> {
+        let mut renderer = Renderer::from(&self.config);
+
+        let kind = renderer.display_kind()?;
+
+        let mut response = Response::empty();
+        if kind != QueryKind::ForeCast {
+            let res = WeatherClient::new(self.cache_length, self.timeout)
+                .query(
+                    QueryKind::Current,
+                    loc,
+                    self.key.clone(),
+                    self.language.as_deref(),
+                )
+                .await?;
+            response.merge(res);
+        }
+        let new_loc = if let Location::Place(_) = loc {
+            let resp = response.as_current()?;
+            Location::LatLon(resp.coord.lat, resp.coord.lon)
+        } else {
+            loc.clone()
+        };
+
+        if kind != QueryKind::Current {
+            let res = WeatherClient::new(self.cache_length, self.timeout)
+                .query(
+                    QueryKind::ForeCast,
+                    &new_loc,
+                    self.key.clone(),
+                    self.language.as_deref(),
+                )
+                .await?;
+            response.merge(res);
+        }
+
+        renderer.render(out, &response)?;
+
+        Ok(())
+    }
+}
+
 pub struct WeatherClient {
     client: reqwest::Client,
     cache_length: Option<Duration>,
@@ -103,21 +173,28 @@ impl WeatherClient {
 
     fn find_cache_for(
         &self,
+        kind: QueryKind,
         location: &Location,
         language: Option<&str>,
     ) -> Result<std::path::PathBuf> {
         if let Some(p) = WeatherClient::directories() {
+            let prefix = match kind {
+                QueryKind::Current => "api",
+                QueryKind::ForeCast => "oapi",
+                QueryKind::Both => bail!("internal error: find_cache_for(Both)"),
+            };
+
             let suffix = match location {
                 Location::LatLon(lat, lon) => format!("{}_{}", lat, lon),
                 Location::Place(p) => self.clean_up_for_path(p),
             };
             let f = if let Some(lang) = language {
-                format!("results/api-{}-{}.json", lang, suffix)
+                format!("results/{}-{}-{}.json", prefix, lang, suffix)
             } else {
-                format!("results/api-{}.json", suffix)
+                format!("results/{}-{}.json", prefix, suffix)
             };
             let file = p.cache_dir().join(f);
-            debug!("looking at cache file at '{}'", file.display());
+            debug!("looking for cache file at '{}'", file.display());
 
             if let Some(p) = file.parent() {
                 std::fs::create_dir_all(p)?;
@@ -146,20 +223,34 @@ impl WeatherClient {
 
     fn query_cache(
         &self,
+        kind: QueryKind,
         location: &Location,
         language: Option<&str>,
-    ) -> Result<Option<CurrentResponse>> {
+    ) -> Result<Option<Response>> {
         if let Some(cache_length) = self.cache_length {
-            let path = self.find_cache_for(location, language)?;
+            let path = self.find_cache_for(kind, location, language)?;
 
             if path.exists() {
                 let m = std::fs::metadata(&path)?;
                 let elapsed = m.modified()?.elapsed()?;
                 if elapsed <= cache_length {
                     let f = std::fs::File::open(&path)?;
-                    if let ApiResponse::Success(resp) = serde_json::from_reader(f)? {
-                        info!("using cached response for {}", location);
-                        return Ok(Some(resp));
+                    match kind {
+                        QueryKind::Current => {
+                            if let CResponse::Success(resp) = serde_json::from_reader(f)? {
+                                info!("using cached response for {}", location);
+
+                                return Ok(Some(Response::from_current(resp)));
+                            }
+                        }
+                        QueryKind::ForeCast => {
+                            if let OResponse::Success(resp) = serde_json::from_reader(f)? {
+                                info!("using cached response for {}", location);
+
+                                return Ok(Some(Response::from_forecast(resp)));
+                            }
+                        }
+                        QueryKind::Both => bail!("internal error: query_cache(Both)"),
                     }
                 } else {
                     info!("ignoring expired cached response for {}", location);
@@ -172,8 +263,14 @@ impl WeatherClient {
         Ok(None)
     }
 
-    fn write_cache(&self, location: Location, language: Option<&str>, bytes: &[u8]) -> Result<()> {
-        let path = self.find_cache_for(&location, language)?;
+    fn write_cache(
+        &self,
+        kind: QueryKind,
+        location: &Location,
+        language: Option<&str>,
+        bytes: &[u8],
+    ) -> Result<()> {
+        let path = self.find_cache_for(kind, location, language)?;
         debug!("writing cache for {}", location);
         std::fs::write(path, bytes)?;
 
@@ -182,11 +279,12 @@ impl WeatherClient {
 
     pub async fn query(
         &self,
-        location: Location,
+        kind: QueryKind,
+        location: &Location,
         key: String,
         language: Option<&str>,
-    ) -> Result<CurrentResponse> {
-        match self.query_cache(&location, language) {
+    ) -> Result<Response> {
+        match self.query_cache(kind, location, language) {
             Ok(Some(resp)) => return Ok(resp),
             Ok(None) => {}
             Err(e) => {
@@ -194,18 +292,19 @@ impl WeatherClient {
             }
         }
 
-        self.query_api(location, key, language).await
+        self.query_api(kind, location, key, language).await
     }
 
     async fn query_api(
         &self,
-        location: Location,
+        kind: QueryKind,
+        location: &Location,
         key: String,
         language: Option<&str>,
-    ) -> Result<CurrentResponse> {
-        debug!("querying {:?}", location);
+    ) -> Result<Response> {
+        debug!("querying {:?} with '{:?}' OpenWeather API", location, kind);
         let mut params = Vec::with_capacity(3);
-        match &location {
+        match location {
             Location::LatLon(lat, lon) => {
                 params.push(("lat", lat.to_string()));
                 params.push(("lon", lon.to_string()));
@@ -219,7 +318,13 @@ impl WeatherClient {
 
         params.push(("appid", key));
 
-        let request = self.client.get(API_URL).query(&params).send();
+        let api_url = match kind {
+            QueryKind::Current => CURRENT_API_URL,
+            QueryKind::ForeCast => ONECALL_API_URL,
+            QueryKind::Both => bail!("internal error: query_api(Both)"),
+        };
+
+        let request = self.client.get(api_url).query(&params).send();
         let request = timeout(self.timeout, request);
 
         let response = request
@@ -238,32 +343,55 @@ impl WeatherClient {
             trace!("received response: {}", std::str::from_utf8(&bytes)?);
         }
 
-        let resp: ApiResponse = serde_json::from_slice(&bytes)?;
-
-        match resp {
-            ApiResponse::Success(w) => {
-                if self.cache_length.is_some() {
-                    if let Err(e) = self.write_cache(location, language.as_deref(), &bytes) {
-                        warn!("error while writing cached response: {}", e);
+        match kind {
+            QueryKind::Current => {
+                let resp: CResponse = serde_json::from_slice(&bytes)?;
+                match resp {
+                    CResponse::Success(w) => {
+                        if self.cache_length.is_some() {
+                            if let Err(e) =
+                                self.write_cache(kind, location, language.as_deref(), &bytes)
+                            {
+                                warn!("error while writing cached response: {}", e);
+                            }
+                        }
+                        Ok(Response::from_current(w))
+                    }
+                    CResponse::OtherInt { cod, message } => {
+                        handle_error(StatusCode::from_u16(cod)?, &message, location)
+                    }
+                    CResponse::OtherString { cod, message } => {
+                        handle_error(cod.parse()?, &message, location)
                     }
                 }
-                Ok(w)
             }
-            ApiResponse::OtherInt { cod, message } => {
-                handle_error(StatusCode::from_u16(cod)?, &message, location)
+            QueryKind::ForeCast => {
+                let resp: OResponse = serde_json::from_slice(&bytes)?;
+                match resp {
+                    OResponse::Success(w) => {
+                        if self.cache_length.is_some() {
+                            if let Err(e) =
+                                self.write_cache(kind, location, language.as_deref(), &bytes)
+                            {
+                                warn!("error while writing cached response: {}", e);
+                            }
+                        }
+                        Ok(Response::from_forecast(w))
+                    }
+                    OResponse::OtherInt { cod, message } => {
+                        handle_error(StatusCode::from_u16(cod)?, &message, location)
+                    }
+                    OResponse::OtherString { cod, message } => {
+                        handle_error(cod.parse()?, &message, location)
+                    }
+                }
             }
-            ApiResponse::OtherString { cod, message } => {
-                handle_error(cod.parse()?, &message, location)
-            }
+            QueryKind::Both => bail!("internal error: query_api(Both)"),
         }
     }
 }
 
-fn handle_error(
-    error_code: StatusCode,
-    message: &str,
-    location: Location,
-) -> Result<CurrentResponse> {
+fn handle_error(error_code: StatusCode, message: &str, location: &Location) -> Result<Response> {
     match error_code {
         StatusCode::NOT_FOUND => bail!("location error: '{}' for '{}'", message, location),
         StatusCode::TOO_MANY_REQUESTS => bail!("Too many calls to the API! If you not using your own API key, please get your own for free over at http://openweathermap.org"),
@@ -277,6 +405,13 @@ pub enum DisplayMode {
     NerdFonts,
     Unicode,
     Ascii,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum QueryKind {
+    Current,
+    ForeCast,
+    Both,
 }
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
+pub mod api;
 pub mod cli;
 pub mod config;
 #[cfg(feature = "geoclue")]
 pub mod geoclue;
-pub mod response;
 pub mod segments;
 mod serde_utils;
 
@@ -12,7 +12,7 @@ use anyhow::*;
 use directories_next::ProjectDirs;
 use log::*;
 use reqwest::StatusCode;
-use response::{ApiResponse, WeatherResponse};
+use api::current::{ApiResponse, CurrentResponse};
 use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
 
@@ -148,7 +148,7 @@ impl WeatherClient {
         &self,
         location: &Location,
         language: Option<&str>,
-    ) -> Result<Option<WeatherResponse>> {
+    ) -> Result<Option<CurrentResponse>> {
         if let Some(cache_length) = self.cache_length {
             let path = self.find_cache_for(location, language)?;
 
@@ -185,7 +185,7 @@ impl WeatherClient {
         location: Location,
         key: String,
         language: Option<&str>,
-    ) -> Result<WeatherResponse> {
+    ) -> Result<CurrentResponse> {
         match self.query_cache(&location, language) {
             Ok(Some(resp)) => return Ok(resp),
             Ok(None) => {}
@@ -202,7 +202,7 @@ impl WeatherClient {
         location: Location,
         key: String,
         language: Option<&str>,
-    ) -> Result<WeatherResponse> {
+    ) -> Result<CurrentResponse> {
         debug!("querying {:?}", location);
         let mut params = Vec::with_capacity(3);
         match &location {
@@ -263,7 +263,7 @@ fn handle_error(
     error_code: StatusCode,
     message: &str,
     location: Location,
-) -> Result<WeatherResponse> {
+) -> Result<CurrentResponse> {
     match error_code {
         StatusCode::NOT_FOUND => bail!("location error: '{}' for '{}'", message, location),
         StatusCode::TOO_MANY_REQUESTS => bail!("Too many calls to the API! If you not using your own API key, please get your own for free over at http://openweathermap.org"),

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -796,6 +796,7 @@ pub struct HourlyForecast {
     pub temp_style: ScaledColor,
     #[serde(with = "option_color_spec")]
     pub style: Option<ColorSpec>,
+    pub step: u8,
     pub hours: u8,
 }
 
@@ -805,6 +806,7 @@ impl Default for HourlyForecast {
             display_mode: Default::default(),
             temp_style: Default::default(),
             style: Default::default(),
+            step: 2,
             hours: 3,
         }
     }
@@ -823,10 +825,13 @@ impl HourlyForecast {
         let mut first = true;
         out.set_color(base_style)?;
 
-        let end = resp.hourly.len().min(1 + self.hours as usize);
+        let hours = self.hours as usize;
+        let step = 1.max(self.step as usize);
+        let end = resp.hourly.len();
 
-        for i in 1..end {
-            let day = &resp.hourly[i as usize];
+        let mut i = 0;
+        while i * step + 1 < end && i < hours {
+            let day = &resp.hourly[i * step + 1];
 
             let dt = day.dt;
 
@@ -861,6 +866,8 @@ impl HourlyForecast {
 
                 out.set_color(base_style)?;
             }
+
+            i += 1;
         }
 
         Ok(RenderStatus::Rendered)

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -47,7 +47,7 @@ impl Renderer {
             out,
             &self.display_config.base_style,
             self.display_config.display_mode,
-            &resp,
+            resp,
         )?;
         for s in self.display_config.segments[1..].iter() {
             out.set_color(&self.display_config.base_style)?;
@@ -58,7 +58,7 @@ impl Renderer {
                 out,
                 &self.display_config.base_style,
                 self.display_config.display_mode,
-                &resp,
+                resp,
             )?;
         }
 
@@ -563,7 +563,7 @@ impl WindSpeed {
                 let speed_color_idx = speed.floor() as usize;
                 let mut tmp_style = base_style.clone();
                 stdout.set_color(
-                    &tmp_style.set_fg(Some(Color::Ansi256(WIND_COLORS[speed_color_idx]))),
+                    tmp_style.set_fg(Some(Color::Ansi256(WIND_COLORS[speed_color_idx]))),
                 )?;
             }
             ScaledColor::Spec(Some(style)) => {
@@ -586,7 +586,7 @@ impl WindSpeed {
         resp: &WeatherResponse,
     ) -> Result<RenderStatus> {
         if let Some(w) = &resp.wind {
-            self.display_wind(out, &w, base_style, display_mode)?;
+            self.display_wind(out, w, base_style, display_mode)?;
             Ok(RenderStatus::Rendered)
         } else {
             Ok(RenderStatus::Empty)

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -1,5 +1,5 @@
 use crate::{config::*, serde_utils::*};
-use crate::{response::Wind, DisplayMode, WeatherResponse, WindType};
+use crate::{api::current::Wind, DisplayMode, CurrentResponse, WindType};
 use anyhow::Result;
 use chrono::{FixedOffset, TimeZone, Utc};
 use log::*;
@@ -35,7 +35,7 @@ impl Renderer {
         Renderer { display_config }
     }
 
-    pub fn render(&mut self, out: &mut StandardStream, resp: &WeatherResponse) -> Result<()> {
+    pub fn render(&mut self, out: &mut StandardStream, resp: &CurrentResponse) -> Result<()> {
         if self.display_config.segments.is_empty() {
             warn!("there are not segments to display!");
             return Ok(());
@@ -90,7 +90,7 @@ impl Segment {
         out: &mut StandardStream,
         base_style: &ColorSpec,
         display_mode: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         match self {
             Segment::Instant(i) => i.render(out, base_style, display_mode, resp),
@@ -135,7 +135,7 @@ impl Instant {
         out: &mut StandardStream,
         _: &ColorSpec,
         _: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         let source_date = FixedOffset::east(resp.timezone).timestamp(resp.dt, 0);
 
@@ -166,7 +166,7 @@ impl LocationName {
         out: &mut StandardStream,
         _: &ColorSpec,
         _: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         if let Some(ref style) = self.style {
             out.set_color(style)?;
@@ -243,7 +243,7 @@ impl Temperature {
         out: &mut StandardStream,
         base_style: &ColorSpec,
         display_mode: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         let temp = resp.main.temp;
         let feels_like = resp.main.feels_like;
@@ -433,7 +433,7 @@ impl WeatherIcon {
         out: &mut StandardStream,
         _: &ColorSpec,
         display_mode: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         if let Some(ref style) = self.style {
             out.set_color(style)?;
@@ -492,7 +492,7 @@ impl WeatherDescription {
         out: &mut StandardStream,
         _: &ColorSpec,
         _: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         if let Some(ref style) = self.style {
             out.set_color(style)?;
@@ -583,7 +583,7 @@ impl WindSpeed {
         out: &mut StandardStream,
         base_style: &ColorSpec,
         display_mode: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         if let Some(w) = &resp.wind {
             self.display_wind(out, w, base_style, display_mode)?;
@@ -637,7 +637,7 @@ impl Humidity {
         out: &mut StandardStream,
         base_style: &ColorSpec,
         display_mode: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         self.display_humidity(out, resp.main.humidity, base_style, display_mode)?;
 
@@ -659,7 +659,7 @@ impl Rain {
         out: &mut StandardStream,
         base_style: &ColorSpec,
         display_mode: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         if let Some(r) = &resp.rain {
             if let Some(mm) = r.one_h.or(r.three_h) {
@@ -694,7 +694,7 @@ impl Snow {
         out: &mut StandardStream,
         base_style: &ColorSpec,
         display_mode: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         if let Some(r) = &resp.snow {
             if let Some(mm) = r.one_h.or(r.three_h) {
@@ -748,7 +748,7 @@ impl Pressure {
         out: &mut StandardStream,
         base_style: &ColorSpec,
         display_mode: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         self.display_pressure(out, resp.main.pressure, base_style, display_mode)?;
 
@@ -789,7 +789,7 @@ impl CloudCover {
         out: &mut StandardStream,
         base_style: &ColorSpec,
         display_mode: DisplayMode,
-        resp: &WeatherResponse,
+        resp: &CurrentResponse,
     ) -> Result<RenderStatus> {
         if let Some(ref clouds) = resp.clouds {
             self.display_cover(out, clouds.all, base_style, display_mode)?;

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -208,6 +208,7 @@ pub(crate) mod segment_vec {
                             "pressure" => Segment::Pressure(Pressure::default()),
                             "cloud_cover" => Segment::CloudCover(CloudCover::default()),
                             "daily_forecast" => Segment::DailyForecast(DailyForecast::default()),
+                            "hourly_forecast" => Segment::HourlyForecast(HourlyForecast::default()),
                             a => {
                                 return Err(de::Error::unknown_variant(
                                     a,
@@ -222,6 +223,7 @@ pub(crate) mod segment_vec {
                                         "rain",
                                         "pressure",
                                         "daily_forecast",
+                                        "hourly_forecast",
                                     ],
                                 ))
                             }

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -207,6 +207,7 @@ pub(crate) mod segment_vec {
                             "rain" => Segment::Rain(Rain::default()),
                             "pressure" => Segment::Pressure(Pressure::default()),
                             "cloud_cover" => Segment::CloudCover(CloudCover::default()),
+                            "daily_forecast" => Segment::DailyForecast(DailyForecast::default()),
                             a => {
                                 return Err(de::Error::unknown_variant(
                                     a,
@@ -220,6 +221,7 @@ pub(crate) mod segment_vec {
                                         "humidity",
                                         "rain",
                                         "pressure",
+                                        "daily_forecast",
                                     ],
                                 ))
                             }


### PR DESCRIPTION
This add support for querying the OpenWeather One Call API:

- existing segments were migrated to be able to use either the original api or the one call API,
- a new daily forecast segment was added to show temperatures and weather icons for the next 1 to 7 days,
- a new hourly forecast segment was added to show temperatures and weather icons for the next 1 to 48 hours,

Also:

- bumped Rust MSRV to 1.53
