### PR TITLE
Add localization support to forecast segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 <!-- next-header -->
 ## [Unreleased] - TBD
 
+### Packaging
+
+* The Minimum Supported Rust Version for girouette is now 1.53.
+
+### Features
+
+* New `daily_forecast` segment to show the temperature and general weather for the next 1 to 7 days. A `days` option controls the number of days to display (defaults to 3).
+* New `hourly_forecast` segment to show the temperature and general weather for each hour in the next 48 hours (defaults to 3). An `hours` option controls the number of hours to display (defaults to 3). A `step` controls how many hours to step over between forecasts (defaults to 2).
+
+### Changes
+
+* **Breaking change**: the `-L/--language` command line option and `language` config option now take a locale value of the form `aa_AA`, like `en_US` or `zh_CN`, instead of a 2-letter country code. girouette will warn if the value is not recognized and then fall back to `en_US` for date/time formatting.
+* If the `language` option is unset, girouette will try to use the `LANG` environment variable, before falling back to `en_US`.
 
 ## [0.5.2] - 2021-07-23
 
@@ -51,7 +64,7 @@
 
 * Allow colors to be set with hexadecimal color codes (e.g. `"#00e8ed"`).
 
-### Changed
+### Changed
 
 * The hard-coded location was removed from the default config. The default is now `auto` if geolocation is enabled, and setting it using `-l/--location` (or in the config) is needed otherwise.
 
@@ -121,7 +134,7 @@
 
 ## [0.2.0] - 2020-03-26
 
-### Added
+### Added
 
 * Support for ASCII and Unicode (emoji) output.
 * Support reading configuration from a file at `$XDG_CONFIG_HOME/girouette/config.yml`
@@ -140,7 +153,7 @@
 * Users can opt-out of the color scale for temp/wind/humidity by specifying a style in the
   segment config, instead of the default of `style: "scaled"`.
 
-### Fixed
+### Fixed
 
 * Ignore the `visibility` value from OpenWeather (instead of throwing an error if missing).
 * Avoid adding double separators when a segment has no output (if there is no rain, etc.).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "pure-rust-locales",
  "time",
  "winapi",
 ]
@@ -761,6 +762,12 @@ checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "pure-rust-locales"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45c49fc4f91f35bae654f85ebb3a44d60ac64f11b3166ffa609def390c732d8"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["unstable-locales"] }
 directories-next = "2"
 humantime = "2"
 log = "0.4"

--- a/config.yml
+++ b/config.yml
@@ -27,10 +27,11 @@ cache: "1m"
 # Value can be a duration ("1h", "2 days", "10min"), defaults to "10s".
 #timeout: "10s"
 
-# Language for location and description segments
+# Language for location names, weather descriptions and date/time formatting.
 #
-# Possible values are any 2-letter code accepted by the Openweather API.
-#language: "ja"
+# Possible values are of the form 'aa_AA' like 'en_US' or 'fr_FR'. Note that
+# OpenWeather only supports a subset of all valid LANG values.
+#language: "ja_JP"
 
 # Background style for the whole bar
 #

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,13 +50,13 @@ pub struct ProgramOptions {
     pub cache: Option<String>,
 
     #[structopt(short = "L", long)]
-    /// Use this language for location names and weather descriptions.
+    /// Use this language for location names, weather descriptions and date formatting.
     ///
     /// This asks OpenWeather to provide location names and weather descriptions
-    /// in the given language.
+    /// in the given language, and uses it to format date and times.
     ///
-    /// Possible values are any 2-letter language code supported by OpenWeather, like
-    /// "jp" (Japanese), "en" (English), "uk" (Ukrainian) or "zh_cn" (Chinese Simpl.).
+    /// Possible values are of the form 'aa_AA' like 'en_US' or 'fr_FR'. Note that
+    /// OpenWeather only supports a subset of all valid LANG values.
     pub language: Option<String>,
 
     #[structopt(long)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ impl Girouette {
             response.merge(res);
         }
 
-        renderer.render(out, &response)?;
+        renderer.render(out, &response, self.language.as_deref())?;
 
         Ok(())
     }
@@ -284,6 +284,8 @@ impl WeatherClient {
         key: String,
         language: Option<&str>,
     ) -> Result<Response> {
+        let language = language.map(|l| l.split_once('_').map(|t| t.0).unwrap_or(l));
+
         match self.query_cache(kind, location, language) {
             Ok(Some(resp)) => return Ok(resp),
             Ok(None) => {}


### PR DESCRIPTION
The language option now requires a language code in the form aa_AA, like
en_US or ja_JP. It defaults to the `LANG` environment variable
otherwise.

The locale is used to print weekday names, and the lang code part is
given to OpenWeather to get location names and weather description in
that language if possible.