### PR TITLE
Fix fallback icons for unknown weather code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixes
 
 * Unknown weather codes used to cause a `N/A` icon to be used as weather icon: we now use basic day/night icons instead (the sun or the moon).
+* The unicode icon for haze is now the same for night as it was for day (the fog emoji).
 
 ## [0.6.2] - 2021-09-10
 

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -1174,7 +1174,7 @@ fn get_unicode(id: u16, night: bool) -> &'static str {
         // mist/fog/smoke/haze/dust/sandstorm/ash
         (_, 701)
         | (_, 711)
-        | (false, 721)
+        | (_, 721)
         | (_, 731)
         | (_, 761)
         | (_, 741)


### PR DESCRIPTION
- use day/night icons as fallback instead of N/A
- use fog emoji haze at night too: close enough
