### PR TITLE
Fix hourly forecast always using daytime icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [0.6.4] - 2021-11-17
 
+### Fixes
+
+* Hourly forecast icons now properly indicate daytime/nighttime.
+
 ### Features
 
 * New `daytime` segment to display sunrise and sunset times for the current day.


### PR DESCRIPTION
We only have the current day's sunset/sunrise data, so if needed we translate
those times to the next day to have reasonable icons for forecast times that
reach into the next day's daytime.
