### PR TITLE
Move to clap v3, rust 1.57, edition 2021

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.53.0 # Rust MSRV
+          - 1.57.0 # Rust MSRV
     steps:
       - uses: actions/checkout@v2
       - name: Install native dependencies
@@ -45,7 +45,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.53.0 # Rust MSRV
+          - 1.57.0 # Rust MSRV
     steps:
       - uses: actions/checkout@v2
       - name: Install native dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 <!-- next-header -->
 ## [Unreleased] - TBD
 
+### Packaging
+
+* The Minimum Supported Rust Version for girouette is now 1.57.
+
 ## [0.6.7] - 2021-12-30
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "girouette"
-version = "0.6.8-dev"
+version = "0.7.0-dev"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "bytes"
@@ -82,14 +82,42 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
 dependencies = [
+ "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
+ "terminal_size",
  "textwrap",
- "unicode-width",
+]
+
+[[package]]
+name = "clap_complete"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fff450c061c4de8162fd6fa0a7a73f70f10c211869a34897724823ed9ec0046"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -184,6 +212,15 @@ dependencies = [
  "humantime",
  "log",
  "termcolor",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -286,6 +323,8 @@ version = "0.7.0-dev"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
+ "clap_complete",
  "config",
  "dbus",
  "dbus-tokio",
@@ -298,7 +337,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "structopt",
  "termcolor",
  "tokio",
  "version_check",
@@ -306,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f072413d126e57991455e0a922b31e4c8ba7c2ffbebf6b78b4f8521397d65cd"
+checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
 dependencies = [
  "bytes",
  "fnv",
@@ -331,12 +369,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -355,13 +390,13 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 0.4.8",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -456,12 +491,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -659,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
@@ -677,6 +721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,9 +737,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -699,12 +752,6 @@ name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-error"
@@ -755,46 +802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,15 +831,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4e0a76dc12a116108933f6301b95e83634e0c47b0afbed6abbaa0601e99258"
+checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
@@ -949,18 +957,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -969,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -1020,39 +1028,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1061,13 +1045,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1083,12 +1067,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "terminal_size"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
- "unicode-width",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+dependencies = [
+ "terminal_size",
 ]
 
 [[package]]
@@ -1203,18 +1197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,9 +1228,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
@@ -1354,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
+checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "girouette"
 version = "0.7.0-dev"
 authors = ["Antoine Gourlay <antoine@gourlay.fr>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.57"
 
 [dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,15 +34,13 @@ dynamic = ["reqwest/default-tls"]
 static = ["reqwest/rustls-tls"]
 geoclue = ["dbus", "dbus-tokio", "futures-util"]
 
-[dependencies.structopt]
-version = "0.3"
-default-features = false
-features = ["suggestions"]
+[dependencies.clap]
+version = "3"
+features = ["derive", "cargo", "wrap_help"]
 
-[build-dependencies.structopt]
-version = "0.3"
-default-features = false
-features = ["suggestions"]
+[build-dependencies.clap]
+version = "3"
+features = ["derive", "cargo", "wrap_help"]
 
 [dependencies.config]
 version = "0.11"
@@ -66,6 +64,7 @@ optional = true
 version_check = "0.9"
 serde = { version = "1", features = ["derive"] }
 log = "0.4"
+clap_complete = "3"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "girouette"
-version = "0.6.8-dev"
+version = "0.7.0-dev"
 authors = ["Antoine Gourlay <antoine@gourlay.fr>"]
 edition = "2018"
 

--- a/build.rs
+++ b/build.rs
@@ -1,21 +1,23 @@
+use clap::IntoApp;
+use clap_complete::{generate_to, Shell};
 use std::env;
+use std::io::Error;
 use std::process::Command;
-use structopt::clap::Shell;
 
 include!("src/cli.rs");
 
-fn main() {
+fn main() -> Result<(), Error> {
     let outdir = match env::var_os("OUT_DIR") {
-        None => return,
+        None => return Err(Error::new(std::io::ErrorKind::Other, "no $OUT_DIR!")),
         Some(outdir) => outdir,
     };
-    let mut app = ProgramOptions::clap();
+    let mut app = ProgramOptions::into_app();
 
-    app.gen_completions("girouette", Shell::Bash, &outdir);
+    generate_to(Shell::Bash, &mut app, "girouette", &outdir)?;
 
-    app.gen_completions("girouette", Shell::Zsh, &outdir);
+    generate_to(Shell::Zsh, &mut app, "girouette", &outdir)?;
 
-    app.gen_completions("girouette", Shell::Fish, outdir);
+    generate_to(Shell::Fish, &mut app, "girouette", outdir)?;
 
     if let Some(v) = version_check::Version::read() {
         println!("cargo:rustc-env=BUILD_RUSTC={}", v)
@@ -32,6 +34,8 @@ fn main() {
         env::var("CARGO_CFG_TARGET_OS").unwrap(),
         env::var("CARGO_CFG_TARGET_ENV").unwrap(),
     );
+
+    Ok(())
 }
 
 fn get_commit_hash() -> Option<String> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -121,7 +121,7 @@ impl ProgramOptions {
             2 => LevelFilter::Warn,
             3 => LevelFilter::Info,
             4 => LevelFilter::Debug,
-            5..=i8::MAX => LevelFilter::Trace,
+            5.. => LevelFilter::Trace,
         };
 
         if level != default {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,21 +1,29 @@
+use clap::ValueHint;
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug, Serialize, Deserialize)]
-#[structopt(
+#[derive(clap::Parser, Debug, Serialize, Deserialize)]
+#[clap(
     about = "Display the current weather using the Openweather API.",
-    setting = structopt::clap::AppSettings::DisableVersion,
+    setting = clap::AppSettings::NoAutoVersion,
+    mut_arg("help", |h| h.help_heading("INFO")),
+    mut_arg("version", |h| h.help_heading("INFO")),
+    version
 )]
 pub struct ProgramOptions {
     /// OpenWeather API key (required for anything more than light testing).
     ///
     /// This option overrides the corresponding value from the config.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub key: Option<String>,
 
-    #[structopt(short, long, allow_hyphen_values(true))]
+    #[clap(
+        short,
+        long,
+        allow_hyphen_values(true),
+        value_hint(ValueHint::FilePath)
+    )]
     /// Location to query (required if not set in config).
     ///
     /// Possible values are:
@@ -24,7 +32,7 @@ pub struct ProgramOptions {
     /// This option overrides the corresponding value from the config.
     pub location: Option<String>,
 
-    #[structopt(long)]
+    #[clap(long, value_name = "FILE")]
     /// Use the specified configuration file instead of the default.
     ///
     /// By default, girouette looks for a configuration file:
@@ -36,7 +44,7 @@ pub struct ProgramOptions {
     /// - on Windows in "%AppData%\Girouette\config\config.yml"
     pub config: Option<PathBuf>,
 
-    #[structopt(short, long)]
+    #[clap(short, long, value_name = "DURATION")]
     /// Cache responses for this long (e.g. "1m", "2 days 6h", "5 sec"), or `none` to disable it.
     ///
     /// If there is a cached response younger than the duration given as argument, it  is returned directly.
@@ -49,7 +57,7 @@ pub struct ProgramOptions {
     /// This option overrides the corresponding value from the config.
     pub cache: Option<String>,
 
-    #[structopt(short = "L", long)]
+    #[clap(short = 'L', long)]
     /// Use this language for location names, weather descriptions and date formatting.
     ///
     /// This asks OpenWeather to provide location names and weather descriptions
@@ -59,21 +67,42 @@ pub struct ProgramOptions {
     /// OpenWeather only supports a subset of all valid LANG values.
     pub language: Option<String>,
 
-    #[structopt(short, long, possible_values(&["metric", "imperial", "standard"]))]
+    #[clap(short, long, possible_values(&["metric", "imperial", "standard"]), value_name = "UNIT")]
     /// Units to use when displaying temperatures and speeds.
-    /// 
+    ///
     /// Possible units are:
-    /// 
+    ///
     /// - metric: Celsius temperatures and kilometers/hour speeds (the default),
-    /// 
+    ///
     /// - imperial: Fahrenheit temperatures and miles/hour speeds,
-    /// 
+    ///
     /// - standard: Kelvin temperatures and meters/second speeds.
-    /// 
+    ///
     /// This option overrides the corresponding value from the config.
     pub units: Option<String>,
 
-    #[structopt(long)]
+    /// Pass for more log output.
+    #[clap(
+        long,
+        short,
+        global = true,
+        parse(from_occurrences),
+        help_heading = "FLAGS"
+    )]
+    verbose: i8,
+
+    /// Pass for less log output.
+    #[clap(
+        long,
+        short,
+        global = true,
+        parse(from_occurrences),
+        conflicts_with = "verbose",
+        help_heading = "FLAGS"
+    )]
+    quiet: i8,
+
+    #[clap(long, exclusive(true), help_heading = "GLOBAL")]
     /// Removes all cached responses and exits.
     ///
     /// This empties the cache directory used when caching responses with "-c/--cache".
@@ -87,29 +116,14 @@ pub struct ProgramOptions {
     /// - on Windows in "%AppData%\Girouette\cache\results\"
     pub clean_cache: bool,
 
-    #[structopt(long)]
+    #[clap(long, exclusive(true), help_heading = "GLOBAL")]
     /// Prints the contents of the default configuration and exits.
     ///
     /// This allows creating a new configuration using the default configuration as a template.
     pub print_default_config: bool,
-
-    /// Prints version information.
-    #[structopt(short = "V", long = "version")]
-    pub version: bool,
-
-    /// Pass for more log output.
-    #[structopt(long, short, global = true, parse(from_occurrences))]
-    verbose: i8,
-
-    /// Pass for less log output.
-    #[structopt(
-        long,
-        short,
-        global = true,
-        parse(from_occurrences),
-        conflicts_with = "verbose"
-    )]
-    quiet: i8,
+    // Prints version information.
+    //#[clap(short = 'V', long = "version", help_heading = "INFO")]
+    //pub version: bool,
 }
 
 impl ProgramOptions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use girouette::{
 };
 use log::*;
 use std::{env, time::Duration};
-use structopt::StructOpt;
+use clap::{Parser, IntoApp, FromArgMatches};
 use termcolor::*;
 use tokio::runtime;
 
@@ -14,7 +14,7 @@ const DEFAULT_TIMEOUT_SEC: u64 = 10;
 const LOG_ENV_VAR: &str = "GIROUETTE_LOG";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let options = ProgramOptions::from_args();
+    let options = ProgramOptions::parse();
 
     let mut b = Builder::default();
     b.format_timestamp(None);
@@ -52,10 +52,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn run_async() -> Result<()> {
-    let options_matches = ProgramOptions::clap().get_matches();
-    let options = ProgramOptions::from_clap(&options_matches);
+    let options_matches = ProgramOptions::into_app().get_matches();
+    let options = ProgramOptions::from_arg_matches(&options_matches)?;
 
-    if options.version {
+    if options_matches.is_present("version") {
         // HACK to disambiguate short/long invocations for the same cli option;
         // there has to be a better way of doing this...
         let i = options_matches


### PR DESCRIPTION
- bump Rust MSRV from 1.53 to 1.57 and move to 2021 edition
- move to clap v3 and use some of its new stuff
