### PR TITLE
Remove alert count when equal to one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 * The `--version` output now shows if a default config file has been found and the size of the girouette cache.
 
+### Fixed
+
+* The alert segment no longer shows an alert count when there is only one alert.
+
 ## [0.6.7] - 2021-12-30
 
 ### Features

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -981,7 +981,9 @@ impl Alerts {
         let timezone = resp.timezone_offset;
 
         for (i, a) in alerts.iter().enumerate() {
-            write!(out, "{}. ", i + 1)?;
+            if alerts.len() != 1 {
+                write!(out, "{}. ", i + 1)?;
+            }
 
             let mut seen_tags = HashSet::new();
             for t in &a.tags {


### PR DESCRIPTION
The alert segment used to show an alert number even when there was only
one alert; that's a waste of horizontal space.
